### PR TITLE
Return nonzero on usage error

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,7 +214,8 @@ int main(int ac, const char* av[])
         	test_io();
 		#endif
         else
-        	cout << "Insufficient arguments. Use diamond -h for help.\n";
+        	cerr << "Insufficient arguments. Use diamond -h for help." << endl;
+        	return 1;
 	}
 	catch(std::bad_alloc &e) {
 		cerr << "Failed to allocate sufficient memory. Please refer to the readme for instructions on memory usage." << endl;


### PR DESCRIPTION
Return nonzero (1) on "Insufficient arguments" error. 

Issue: https://github.com/bbuchfink/diamond/issues/15