### PR TITLE
Only return 1 when complaning about insufficient arguments

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,9 +214,10 @@ int main(int ac, const char* av[])
         else if (command == "test")
         	test_io();
 		#endif
-        else
+        else {
         	cerr << "Insufficient arguments. Use diamond -h for help." << endl;
         	return 1;
+	}
 	}
 	catch(std::bad_alloc &e) {
 		cerr << "Failed to allocate sufficient memory. Please refer to the readme for instructions on memory usage." << endl;


### PR DESCRIPTION
The code introduced in 3660416b9 did always trigger due to missing curly braces.

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>