### PR TITLE
Some edits to work with GCC 6.1 on Mac OS X:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ install_manifest.txt
 
 build/
 .idea
+Makefile
+diamond

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(ZLIB REQUIRED)
 find_package(Threads REQUIRED)
 
 set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-uninitialized")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-uninitialized -Wno-deprecated-declarations")
 
 include_directories(
   "${CMAKE_SOURCE_DIR}/src"

--- a/src/align/align_sequence_anchored.cpp
+++ b/src/align/align_sequence_anchored.cpp
@@ -106,9 +106,15 @@ void load_local_trace_points(vector<local_trace_point> &v, vector<Subject_seq> &
 void rank_subjects(vector<Subject_seq> &subjects, vector<local_trace_point> &tp)
 {
 	std::sort(subjects.begin(), subjects.end());
-	unsigned score = config.toppercent < 100 ?
-		(unsigned)((double)subjects[0].filter_score * (1.0 - config.toppercent / 100.0) * config.rank_ratio)
-		: (unsigned)((double)subjects[std::min(subjects.size(), config.max_alignments) - 1].filter_score * config.rank_ratio);
+
+  unsigned score = 0;
+  if (config.toppercent < 100) {
+    score = (double) subjects[0].filter_score * (1.0 - config.toppercent / 100.0) * config.rank_ratio;
+  } else {
+    size_t min_idx = (subjects.size() < config.max_alignments) ? subjects.size() : config.max_alignments;
+    score = (double) subjects[min_idx - 1].filter_score * config.rank_ratio;
+  }
+
 	unsigned i = 0;
 	for (; i < subjects.size(); ++i)
 		if (subjects[i].filter_score < score)

--- a/src/basic/config.h
+++ b/src/basic/config.h
@@ -149,18 +149,13 @@ struct Config
 			return padding;
 	}
 
-	bool mem_buffered() const
-	{
-		return tmpdir == "/dev/shm";
-	}
+	bool mem_buffered() const { return tmpdir == "/dev/shm"; }
+
+  // Fix for Mac OS X GCC 6.1
+  static void set_option(uint64_t& option, size_t value) { if (option == 0) option = value; }
 
 	template<typename _t>
-	static void set_option(_t& option, _t value)
-	{
-		if (option == 0)
-			option = value;
-	}
-
+	static void set_option(_t& option, _t value) { if (option == 0) option = value; }
 };
 
 extern Config config;

--- a/src/dp/dp.h
+++ b/src/dp/dp.h
@@ -20,6 +20,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define DP_H_
 
 #include "../basic/match.h"
+#include "../align/align.h"
 
 template<typename _score>
 void smith_waterman(const Letter *query, local_match &segment, _score gap_open, _score gap_extend, vector<char> &transcript_buf, const _score& = int());

--- a/src/dp/floating_sw.h
+++ b/src/dp/floating_sw.h
@@ -20,6 +20,7 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR P
 #define FLOATING_SW_H_
 
 #include "../basic/match.h"
+#include "../align/align.h"
 
 struct Score_only { };
 struct Traceback { };

--- a/src/output/output_format.cpp
+++ b/src/output/output_format.cpp
@@ -120,7 +120,7 @@ void XML_format::print_query_epilog(const DAA_query_record &r, Text_buffer &out)
 		<< "  <Iteration_stat>" << '\n'
 		<< "    <Statistics>" << '\n'
 		<< "      <Statistics_db-num>" << ref_header.sequences << "</Statistics_db-num>" << '\n'
-		<< "      <Statistics_db-len>" << config.db_size << "</Statistics_db-len>" << '\n'
+		<< "      <Statistics_db-len>" << (size_t) config.db_size << "</Statistics_db-len>" << '\n'
 		<< "      <Statistics_hsp-len>0</Statistics_hsp-len>" << '\n'
 		<< "      <Statistics_eff-space>0</Statistics_eff-space>" << '\n'
 		<< "      <Statistics_kappa>").print_d(score_matrix.k()) << "</Statistics_kappa>" << '\n'


### PR DESCRIPTION
Hi,

You might be interested in these minor edits I had to do to get DIAMOND to compile on Mac OS X 10.11 with GCC 6.1.

- Added -Wno-deprecated-declarations because of auto_ptr
- Explicitely defined set_config for uint64_t
- Manually cast uint64_t as size_t in ostream
- Explicitely code min() for differing types
- Added missing headers