### PR TITLE
Remove -static to allow compilation on OSX

### DIFF
--- a/build_simple.sh
+++ b/build_simple.sh
@@ -1,5 +1,5 @@
 gcc -c -O3 -DNDEBUG src/blast/sm_blosum45.c src/blast/sm_blosum50.c src/blast/sm_blosum62.c src/blast/sm_blosum80.c src/blast/sm_blosum90.c src/blast/sm_pam30.c src/blast/sm_pam70.c src/blast/sm_pam250.c
-g++ -DNDEBUG -O3 -mssse3 -Wno-deprecated-declarations -std=gnu++98 -static \
+g++ -DNDEBUG -O3 -mssse3 -Wno-deprecated-declarations -std=gnu++98 \
   sm*.o \
   src/run/main.cpp \
   src/basic/config.cpp \


### PR DESCRIPTION
`cmake` is not part of the xcode stack. `build_simple.sh` works if `-static` is removed as, unfortunately, some of the OSX does not ship with static builds of some of the core libraries. Addresses #74