### PR TITLE
Fix Merge Sort thread

### DIFF
--- a/src/util/merge_sort.h
+++ b/src/util/merge_sort.h
@@ -20,8 +20,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MERGE_SORT_H_
 
 #include <algorithm>
+#include <cmath>
 #include <stddef.h>
 #include "thread.h"
+#include <cmath>
 
 template<typename _it>
 void merge_sort(_it begin, _it end, unsigned n_threads, unsigned level = 0)
@@ -29,8 +31,9 @@ void merge_sort(_it begin, _it end, unsigned n_threads, unsigned level = 0)
 	ptrdiff_t diff = end - begin;
 	if(diff <= 1)
 		return;
-
-	if(1u << level >= n_threads) {
+	// The total number of threads at a given level is equal 2^(level)
+	// If the overhead of the pow function start to be problem you can replace it by a left-shit (1 << level)
+	if(1u << int(std::pow(2,level)) >= n_threads) {
 		std::sort(begin, end);
 		return;
 	}


### PR DESCRIPTION
This pull-request fix the `merge_sort` function to test the correct criterum related to the number of thread.

Indeed, The number of thread in Merge_sort double at each recursion. Hence the maximum number of current threads is 2^(level).

PS : This bug was maybe the cause of different reported segault  (#114 #133).