### PR TITLE
Fix build error: unknown type name 'ref_header'

### DIFF
--- a/src/data/reference.cpp
+++ b/src/data/reference.cpp
@@ -116,7 +116,7 @@ void make_db()
 #ifdef EXTRA
 	uint64_t offset = sizeof(ReferenceHeader) + sizeof(ReferenceHeader2);
 #else
-	uint64_t offset = sizeof(ref_header);
+	uint64_t offset = sizeof(ReferenceHeader);
 #endif
 	Sequence_set *seqs;
 	String_set<0> *ids;


### PR DESCRIPTION
This fixes the build on FreeBSD after a0203d7, but I am not certain it is correct.