### PR TITLE
Add more detailed errors for invalid output fields

### DIFF
--- a/src/output/blast_tab_format.cpp
+++ b/src/output/blast_tab_format.cpp
@@ -243,7 +243,11 @@ void Blast_tab_format::print_match(const Hsp_context& r, const Metadata &metadat
 			out << r.subject_seq;
 			break;
 		default:
-			throw std::runtime_error("Invalid output field");
+				const int max_field_num = sizeof(field_str) / sizeof(field_str[0]);
+				if (*i > max_field_num)
+					throw std::runtime_error("Invalid output field");
+				else
+					throw std::runtime_error(string("Invalid output field: ") + field_str[*i]);
 		}
 		if (i < fields.end() - 1)
 			out << '\t';
@@ -299,7 +303,11 @@ void Blast_tab_format::print_query_intro(size_t query_num, const char *query_nam
 				out << query_name;
 				break;
 			default:
-				throw std::runtime_error("Invalid output field");
+				const int max_field_num = sizeof(field_str) / sizeof(field_str[0]);
+				if (*i > max_field_num)
+					throw std::runtime_error("Invalid output field (query_intro)");
+				else
+					throw std::runtime_error(string("Invalid output field (query_intro): ") + field_str[*i]);
 			}
 			if (i < fields.end() - 1)
 				out << '\t';			


### PR DESCRIPTION
The BLAST tabular style output (output format 6) in DIAMOND supports a set of keywords that are not the same as those supported by BLAST. The [current test](https://github.com/bbuchfink/diamond/blob/master/src/output/blast_tab_format.cpp#L87) for unsupported field names checks against the complete list of possible field names, not all of which are supported.

This patch adds more instructive output to the error messages created when a field that is in `Blast_tab_format::field_str` is chosen but it is not in fact supported (by either `Blast_tab_format::print_match` or `Blast_tab_format::print_query_intro`).