### PR TITLE
Fix build on FreeBSD by removing assert referencing config.window

### DIFF
--- a/src/search/collision.cpp
+++ b/src/search/collision.cpp
@@ -92,7 +92,6 @@ bool is_primary_hit(const Letter *query,
 	const unsigned sid,
 	const unsigned len)
 {
-	assert(len > 0 && len <= config.window * 2);
 	const bool chunked(config.lowmem > 1);
 	uint64_t mask = reduced_match32(query, subject, len);
 	unsigned i = 0;


### PR DESCRIPTION
Hello Benjamin,

An unpatched 0.9.36 would fail to build with the error: [`/wrkdirs/usr/ports/biology/diamond/work/diamond-0.9.36/src/search/collision.cpp:96:34: error: no member named 'window' in 'Config'`](http://pkg.awarnach.mathstat.dal.ca/data/12amd64-default/2020-07-02_22h01m38s/logs/errors/diamond-0.9.36.log).

After patching, the build finished, but I am unclear of the consequences.

Regards,

Joe