### PR TITLE
Fix 2.0.11 FreeBSD build

### DIFF
--- a/src/util/system/system.cpp
+++ b/src/util/system/system.cpp
@@ -192,7 +192,7 @@ void unmap_file(char* ptr, size_t size, int fd) {
 }
 
 size_t l3_cache_size() {
-#if defined(_MSC_VER) || defined(__APPLE__)
+#if defined(_MSC_VER) || defined(__APPLE__) || defined(__FreeBSD__)
 	return 0;
 #else
 	const auto s = sysconf(_SC_LEVEL3_CACHE_SIZE);


### PR DESCRIPTION
diamond-2.0.11/src/util/system/system.cpp:198:25:
error: use of undeclared identifier '_SC_LEVEL3_CACHE_SIZE'
const auto s = sysconf(_SC_LEVEL3_CACHE_SIZE);