### PR TITLE
Fix weird build error with gcc10+

### DIFF
--- a/src/align/align.h
+++ b/src/align/align.h
@@ -54,7 +54,6 @@ namespace ExtensionPipeline {
 				QueryMapper(query_id, begin, end, cfg)
 			{}
 			virtual void run(Statistics &stat) override;
-			virtual ~Pipeline() {}
 		};
 	}
 	namespace BandedSwipe {


### PR DESCRIPTION
The presence of this unimplemented destructor causes linking issues with newer gcc with -O2, and only -O2. Which isn't an issue when BUILD_TYPE is Release, but is when it's RelWithDebInfo. 

Further details are in https://github.com/spack/spack/issues/28295

I tried to report this as a compiler error to my distro, but they were uninterested in something that I couldn't reproduce outside of this code base.