### PR TITLE
Fix for gcc-13 build

### DIFF
--- a/src/lib/MemoryPool/MemoryPool.tcc
+++ b/src/lib/MemoryPool/MemoryPool.tcc
@@ -23,7 +23,7 @@
 #ifndef MEMORY_BLOCK_TCC
 #define MEMORY_BLOCK_TCC
 
-
+#include <cstdint>
 
 template <typename T, size_t BlockSize>
 inline typename MemoryPool<T, BlockSize>::size_type

--- a/src/util/log_stream.h
+++ b/src/util/log_stream.h
@@ -79,7 +79,7 @@ struct task_timer
 	{}
 	~task_timer()
 	{
-		if (!std::uncaught_exception())
+		if (!std::uncaught_exceptions())
 			finish();
 	}
 	void go(const char* msg = nullptr)


### PR DESCRIPTION
One issue popped up when porting workload to other compilers/systems. I will let you know if there are others.

Added explicit #include <cstdint> to enable builds with newer compiler.