### PR TITLE
Fix build with clang 17

### DIFF
--- a/src/util/data_structures/deque.h
+++ b/src/util/data_structures/deque.h
@@ -186,6 +186,11 @@ struct Deque {
 			return *this;
 		}
 
+		Iterator& operator-=(ptrdiff_t i) {
+			i_ -= i;
+			return *this;
+		}
+
 	private:
 
 		ptrdiff_t i_;


### PR DESCRIPTION
Fix build by adding the -= operator to Deque's random access iterator.

Submitted-by: Dimitry Andric <dim@FreeBSD.org>