### PR TITLE
Change FDIV to FMUL

### DIFF
--- a/src/lib/alp/sls_basic.hpp
+++ b/src/lib/alp/sls_basic.hpp
@@ -52,6 +52,7 @@ Contents: Some basic functions and types
 namespace Sls { 
 
 	const double pi=3.1415926535897932384626433832795;
+	const double invsqrttwo=0.707106769084930419921875;
 	const double const_val=1/sqrt(2.0*pi);
 	const long int quick_tests_trials_number=100;
 
@@ -189,7 +190,7 @@ namespace Sls {
 
 		static double normal_probability(double x_)
 		{
-			return 0.5*erfc(-sqrt(0.5)*x_);
+			return 0.5*erfc(-invsqrttwo*x_);
 		}
 
 		static double normal_probability(

--- a/src/lib/alp/sls_basic.hpp
+++ b/src/lib/alp/sls_basic.hpp
@@ -52,7 +52,7 @@ Contents: Some basic functions and types
 namespace Sls { 
 
 	const double pi=3.1415926535897932384626433832795;
-	const double invsqrttwo=0.707106769084930419921875;
+	const double invsqrttwo=sqrt(0.5);
 	const double const_val=1/sqrt(2.0*pi);
 	const long int quick_tests_trials_number=100;
 

--- a/src/masking/tantan.cpp
+++ b/src/masking/tantan.cpp
@@ -98,12 +98,13 @@ Mask::Ranges mask(Letter *seq,
 	}
 
 	const float z = b * b2b + f.sum() * p_repeat_end;
+	const float zinv = 1.0/z;
 	b = b2b;
 	f = p_repeat_end;
 	Mask::Ranges ranges;
 
 	for (int i = len - 1; i >= 0; --i) {
-		const float pf = 1 - (pb[i] * b / z);
+		const float pf = 1 - (pb[i] * b * zinv);
 
 		if ((i & 15) == 15) {
 			const float s = scale[i / 16];


### PR DESCRIPTION
Some small performance improvement from safely changing a couple floating point divides to floating point multiplies.

FDIV is more expensive than FMUL on most hardware, but actual improvements will be microarchitecture specific.