### PR TITLE
fix: include `<string>` in binary_buffer.h for fix macos builds

### DIFF
--- a/src/util/binary_buffer.h
+++ b/src/util/binary_buffer.h
@@ -22,7 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdexcept>
 #include <stdint.h>
 #include <utility>
-#include <string.h>
+#include <string.h> // memcpy
+#include <string> // std::string
 #include "algo/varint.h"
 
 struct BinaryBuffer : public std::vector<char>


### PR DESCRIPTION
include `<string>` to fix some compile issue as below

```
  In file included from /tmp/diamond-20250125-4855-7vw53/diamond-2.1.11/src/basic/packed_transcript.h:21:
  /tmp/diamond-20250125-4855-7vw53/diamond-2.1.11/src/util/binary_buffer.h:93:8: error: implicit instantiation of undefined template 'std::basic_string<char>'
                                  dst.push_back(c);
                                     ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/c++/v1/iosfwd:248:32: note: template is declared here
      class _LIBCPP_TEMPLATE_VIS basic_string;
                                 ^
```

relates to https://github.com/Homebrew/homebrew-core/pull/205487