### PR TITLE
fix gcc error caused by missing include cstring

### DIFF
--- a/src/search/finger_print.h
+++ b/src/search/finger_print.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 #include "util/simd.h"
 #include "basic/value.h"
+#include <cstring>
 
 #ifdef __AVX2__
 


### PR DESCRIPTION
diamond compile failed caused by not explicitly including \<cstring\>.The crucial log is here:
"/build/reproducible-path/diamond-aligner-2.1.11/src/search/finger_print.h:138:17:
error: ‘memcpy’ was not declared in this scope
  138 |                 memcpy(r, q - 16, 48);
      |                 ^~~~~~
/build/reproducible-path/diamond-aligner-2.1.11/src/search/finger_print.h:26:1:
note: ‘memcpy’ is defined in header ‘<cstring>’; this is probably
fixable by adding ‘#include \<cstring\>’
   25 | #include "basic/value.h"
  +++ |+#include <cstring>
   26 |
"
This issue can be fixed by "#include \<cstring\>"