### PR TITLE
Fix two help URLs

### DIFF
--- a/src/basic/config.cpp
+++ b/src/basic/config.cpp
@@ -690,7 +690,7 @@ Config::Config(int argc, const char **argv, bool check_io, CommandLineParser& pa
 	if (verbosity >= 1 || command == regression_test) {
 		ostream& header_out = command == Config::help ? cout : cerr;
 		header_out << Const::program_name << " v" << Const::version_string << "." << (unsigned)Const::build_version << " (C) Max Planck Society for the Advancement of Science, Benjamin Buchfink, University of Tuebingen" << endl;
-		header_out << "Documentation, support and updates available at http://www.diamondsearch.org" << endl;
+		header_out << "Documentation, support and updates available at https://github.com/bbuchfink/diamond/wiki" << endl;
 		header_out << "Please cite: http://dx.doi.org/10.1038/s41592-021-01101-x Nature Methods (2021)" << endl << endl;
 	}
 	log_stream << Const::program_name << " v" << Const::version_string << "." << (unsigned)Const::build_version << endl;

--- a/src/util/command_line_parser.cpp
+++ b/src/util/command_line_parser.cpp
@@ -123,7 +123,7 @@ void CommandLineParser::print_help()
     cout << endl;
     cout << "Possible [OPTIONS] for COMMAND can be seen with syntax: diamond COMMAND" <<endl;
 	cout << endl;
-	cout << "Online documentation at http://www.diamondsearch.org" << endl;
+	cout << "Online documentation at https://github.com/bbuchfink/diamond/wiki" << endl;
 }
 void CommandLineParser::print_documentation(int command)
 {


### PR DESCRIPTION
Replaced two printed help strings that referenced http://www.diamondsearch.org with [[https://<official-docs-url>](https://github.com/bbuchfink/diamond/wiki)](https://github.com/bbuchfink/diamond/wiki).

Fixes #901