### PR TITLE
Fix build failures on macOS with Clang 17+

### DIFF
--- a/src/cluster/cluster.h
+++ b/src/cluster/cluster.h
@@ -75,7 +75,7 @@ std::vector<Int2> convert_mapping(const std::vector<Int>& mapping, Int2) {
 }
 
 struct Mapback : public Consumer {
-	static const OId NIL_VALUE = (OId)-1;
+	static constexpr OId NIL_VALUE = (OId)-1;
 	Mapback(int64_t count) :
 		centroid_id(count, NIL_VALUE)
 	{}

--- a/src/util/data_structures/flat_array.h
+++ b/src/util/data_structures/flat_array.h
@@ -1,5 +1,5 @@
 /****
-Copyright © 2013-2025 Benjamin J. Buchfink <buchfink@gmail.com>
+Copyright ï¿½ 2013-2025 Benjamin J. Buchfink <buchfink@gmail.com>
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
@@ -65,7 +65,11 @@ struct FlatArray {
 
 	template<typename It>
 	void push_back(const It begin, const It end) {
+	#if __cplusplus >= 202002L
+		std::for_each(begin, end, [&](auto&& v){ data_.push_back(v); });
+	#else
 		data_.insert(data_.end(), begin, end);
+	#endif
 		limits_.push_back(limits_.back() + (end - begin));
 	}
 

--- a/src/util/log_stream.h
+++ b/src/util/log_stream.h
@@ -1,5 +1,5 @@
 /****
-Copyright © 2013-2025 Benjamin J. Buchfink <buchfink@gmail.com>
+Copyright ï¿½ 2013-2025 Benjamin J. Buchfink <buchfink@gmail.com>
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
@@ -87,7 +87,7 @@ struct TaskTimer
 	{}
 	~TaskTimer()
 	{
-#if (__cplusplus >= 201703L && !defined(__APPLE__)) || defined(_MSC_VER)
+#if (__cplusplus >= 201703L || defined(_MSC_VER))
 		if (!std::uncaught_exceptions())
 #else
 		if (!std::uncaught_exception())


### PR DESCRIPTION
Hello. I'm a maintainer for Homebrew. We've been carrying a number of workarounds to get diamond to build on modern versions of macOS with Clang 17+. This PR introduces a few changes that allow diamond to build on modern macOS toolchains while maintaining backwards compatibility.