### PR TITLE
fix: include <algorithm> in filestack.cpp

### DIFF
--- a/src/util/parallel/filestack.cpp
+++ b/src/util/parallel/filestack.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <string>
 #include <string.h>
 #include <iostream>
+#include <algorithm>
 #include <chrono>
 #include <thread>
 #include <stdexcept>


### PR DESCRIPTION
`filestack.cpp` uses `std::remove`, so it needs `<algorithm>` included directly.

This include was present in earlier releases but seems to have been dropped during recent updates. Without it, the Homebrew 2.1.25 build fails on Linux arm64:

```
filestack.cpp:325:42: error: cannot convert
'std::vector<std::__cxx11::basic_string<char> >::iterator' to 'const char*'
tokens.erase(std::remove(tokens.begin(), tokens.end(), line), tokens.end());
```

https://github.com/Homebrew/homebrew-core/pull/281050