### PR TITLE
Splitting blocks larger than supported.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,6 +547,7 @@ add_test(NAME blastp-blocked COMMAND ${CMAKE_COMMAND} -DNAME=blastp-blocked "-DA
 add_test(NAME linclust COMMAND ${CMAKE_COMMAND} -DNAME=linclust "-DARGS=linclust -d ${TD}/nr_10k.faa -p4 --approx-id 0" ${SP})
 add_test(NAME linclust_reps COMMAND ${CMAKE_COMMAND} -DTEST_DIR=${CMAKE_SOURCE_DIR}/src/test -P ${CMAKE_SOURCE_DIR}/src/test/linclust_reps.cmake)
 add_test(NAME realign COMMAND ${CMAKE_COMMAND} -DNAME=realign "-DARGS=realign -d ${TD}/nr_10k.faa -p1 --clusters ${TD}/linclust.out" ${SP})
+add_test(NAME unit COMMAND diamond test)
 add_test(NAME blastp-daa COMMAND ${CMAKE_COMMAND} -DNAME=blastp-daa "-DARGS=blastp -q ${TD}/nr_300.faa -d nr_10k.dmnd -p1 -f 100 -c1 --no-auto-append --daa-build-version 179" ${SP})
 add_test(NAME view COMMAND ${CMAKE_COMMAND} -DNAME=view "-DARGS=view -a ${TD}/test.daa -p4 -k0" ${SP})
 add_diamond_test(diamond-test-blastp-default "blastp -q ${TD}/data.faa -d ${TD}/data.faa -p1")

--- a/src/cluster/multinode/len_sort.cpp
+++ b/src/cluster/multinode/len_sort.cpp
@@ -19,9 +19,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <inttypes.h>
 #include <atomic>
+#include <cstdio>
+#include <exception>
 #include <limits>
 #include <memory>
 #include "multinode.h"
+#include "len_sort.h"
 #include "util/data_structures/queue.h"
 #include "util/parallel/simple_thread_pool.h"
 #include "util/log_stream.h"
@@ -38,6 +41,28 @@ using std::vector;
 using std::endl;
 using std::tie;
 using std::atomic;
+
+bool Cluster::Multinode::can_add_to_len_sorted_block(
+	uint64_t block_letters,
+	uint64_t block_seqs,
+	uint64_t seq_len,
+	uint64_t block_letter_limit,
+	uint64_t block_seq_limit,
+	uint64_t block_raw_limit)
+{
+	if (seq_len > block_raw_limit)
+		return false;
+	if (block_letters > block_raw_limit - seq_len)
+		return false;
+	const uint64_t raw_len = block_letters + seq_len + block_seqs + 1 + LEN_SORT_BLOCK_RAW_PADDING;
+	if (raw_len > block_raw_limit)
+		return false;
+	if (block_seqs == 0)
+		return true;
+	if (block_seqs >= block_seq_limit)
+		return false;
+	return block_letters + seq_len <= block_letter_limit;
+}
 
 struct OutputChunk {
 	static constexpr size_t POISON = std::numeric_limits<size_t>::max();
@@ -165,8 +190,10 @@ static void write_blocks(Job& job, VolumedFile& volumes, vector<unique_ptr<ofstr
 string len_sort(Job& job, VolumedFile& volumes) {
 	Atomic lock(job.root_dir() + "lensort_lock", job), done(job.root_dir() + "lensort_done", job);
 	const bool first_round_linear = job.is_linear_round();
-	const string input_parts = job.root_dir() + "input.tsv", input_letters = job.root_dir() + "input_letters.txt";
+	const string input_parts = job.root_dir() + "input.tsv", input_letters = job.root_dir() + "input_letters.txt", error_file = job.root_dir() + "lensort_error";
 	if (lock.fetch_add() == 0) {
+		try {
+		std::remove(error_file.c_str());
 		job.log("Memory limit = %" PRIu64, job.mem_limit);
 		vector<pair<Loc, OId>> lengths;
 		uint64_t letters = 0;
@@ -211,7 +238,7 @@ string len_sort(Job& job, VolumedFile& volumes) {
 		} else
 			tie(block_gb, index_chunks) = ::block_size(job.mem_limit, letters, Sensitivity::FAST, true, config.threads_); // TODO take cluster steps into account here
 		const uint64_t block_size = gb_to_bytes(block_gb);
-		job.log("Block size = %" PRIu64 ", index chunks = %d", block_size, index_chunks);
+		job.log("Block size = %" PRIu64 ", index chunks = %d, max sequences per block = %" PRIu64, block_size, index_chunks, Cluster::Multinode::LEN_SORT_BLOCK_SEQ_LIMIT);
 		ips4o::parallel::sort(lengths.begin(), lengths.end(), std::greater<pair<Loc, OId>>(), config.threads_);
 		ofstream idx(input_parts);
 		vector<unique_ptr<ofstream>> out;
@@ -221,12 +248,16 @@ string len_sort(Job& job, VolumedFile& volumes) {
 		OId new_oid = 0;
 		for (vector<pair<Loc, OId>>::const_iterator i = lengths.begin(); i != lengths.end();) {
 			uint64_t block_letters = 0, seqs = 0;
-			while (i != lengths.end() && block_letters + i->first <= block_size) {
+			while (i != lengths.end() && Cluster::Multinode::can_add_to_len_sorted_block(block_letters, seqs, i->first, block_size)) {
 				block_letters += i->first;
 				block_mapping[i->second] = { block, new_oid++ };
 				++i;
 				++seqs;
 			}
+			if (seqs == 0)
+				throw runtime_error("Sequence exceeds supported maximum block size.");
+			if (!first_round_linear && i != lengths.end())
+				throw runtime_error("The first clustering round requires multiple input blocks. Start with a linear clustering round or lower the input size.");
 			ss << seqs << '\t' << block_letters << endl;
 			const string block_idx = std::to_string(block);
 			const string name = job.root_dir() + "input" + block_idx + ".faa";
@@ -238,9 +269,22 @@ string len_sort(Job& job, VolumedFile& volumes) {
 		job.log(ss.str().c_str());
 		write_blocks(job, volumes, out, acc_out, block_mapping);
 		done.fetch_add();
+		} catch (const std::exception& e) {
+			ofstream error_out(error_file);
+			error_out << e.what() << endl;
+			error_out.close();
+			done.fetch_add();
+			throw;
+		}
 	}
 	else
 		done.await(1);
+	ifstream error_in(error_file);
+	if (error_in) {
+		string message;
+		getline(error_in, message);
+		throw runtime_error(message.empty() ? "Length sorting failed." : message);
+	}
 	uint64_t letters, seq_count;
 	ifstream input_letters_file(input_letters);
 	input_letters_file >> letters >> seq_count;

--- a/src/cluster/multinode/len_sort.h
+++ b/src/cluster/multinode/len_sort.h
@@ -1,0 +1,39 @@
+/****
+DIAMOND protein sequence aligner
+Copyright (C) 2012-2026 Benjamin J. Buchfink
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+****/
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+#include <stdint.h>
+#include <limits>
+#include "basic/value.h"
+
+namespace Cluster { namespace Multinode {
+
+constexpr uint64_t LEN_SORT_BLOCK_SEQ_LIMIT = (uint64_t)std::numeric_limits<BlockId>::max() - 1;
+constexpr uint64_t LEN_SORT_BLOCK_RAW_LIMIT = (uint64_t(1) << 40) - 1;
+constexpr uint64_t LEN_SORT_BLOCK_RAW_PADDING = 256;
+
+bool can_add_to_len_sorted_block(
+	uint64_t block_letters,
+	uint64_t block_seqs,
+	uint64_t seq_len,
+	uint64_t block_letter_limit,
+	uint64_t block_seq_limit = LEN_SORT_BLOCK_SEQ_LIMIT,
+	uint64_t block_raw_limit = LEN_SORT_BLOCK_RAW_LIMIT);
+
+} }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -18,6 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <iostream>
+#include <stdexcept>
+#include "cluster/multinode/len_sort.h"
 
 int run_queue_stress_test();
 int run_hit_buffer_stress_test();
@@ -25,8 +27,25 @@ void filestack();
 
 namespace Test {
 
+static void require(bool value, const char* message) {
+	if (!value)
+		throw std::runtime_error(message);
+}
+
+static void len_sort_block_limits() {
+	using Cluster::Multinode::can_add_to_len_sorted_block;
+	require(can_add_to_len_sorted_block(90, 9, 10, 100, 10, 1000), "Expected the last allowed sequence to fit.");
+	require(!can_add_to_len_sorted_block(100, 10, 1, 1000, 10, 1000), "Expected sequence count cap to stop the block.");
+	require(!can_add_to_len_sorted_block(90, 9, 11, 100, 10, 1000), "Expected letter cap to stop a non-empty block.");
+	require(can_add_to_len_sorted_block(0, 0, 200, 100, 10, 1000), "Expected a single oversized sequence to form a block.");
+	require(can_add_to_len_sorted_block(10, 2, 1, 1000, 10, 270), "Expected raw packed-position cap boundary to fit.");
+	require(!can_add_to_len_sorted_block(10, 2, 2, 1000, 10, 270), "Expected raw packed-position cap to stop the block.");
+	require(!can_add_to_len_sorted_block(0, 0, 800, 1000, 10, 1000), "Expected an unrepresentable sequence to fail.");
+}
+
 int run() {
-	std::cerr << "The test workflow is deprecated. Unit testing is available via CTest. No action was taken." << std::endl;
+	len_sort_block_limits();
+	std::cerr << "Unit tests passed." << std::endl;
 	return 0;
 	//filestack();	
 	


### PR DESCRIPTION
Length-sorted blocks can exceed 4.3B sequences which causes overflow on the 32bit per-block sequence ids.

## Summary

Prevent large-memory deepclust length sorting from creating input blocks that exceed 2^32-1 by creating additional input blocks when exceeding a limit. Currently for:

- Per-block sequence ids (32-bit)
- Packed sequence offsets (40-bit)

## Details

- Add `Cluster::Multinode::can_add_to_len_sorted_block()` to centralize length-sort block limit checks.
- Cap blocks by requested letter block size *and* current representation limits.
- Preserve single-sequence block behavior when one sequence exceeds the requested letter block size but still fits representation limits (should never happen).
- Fail clearly if one sequence exceeds the packed offset limit (should never happen).
- Fail clearly for custom non-linear first rounds requiring multiple capped input blocks, because that path currently only processes `input0.faa`.
- Propagate length-sort failures to waiting multiprocessing workers via a `lensort_error` marker to avoid hangs (just for bookkeeping to have all threads throw a clean error).
- Unit test to enforce block-limit boundary behaviors.

## Validation

- `cmake --build diamond/build --target diamond -j 128`
- `ctest --test-dir diamond/build --output-on-failure`