### PR TITLE
Compute linear block-combo search chunk size from block file sizes.

### DIFF
--- a/src/cluster/multinode/len_sort.h
+++ b/src/cluster/multinode/len_sort.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 #include <stdint.h>
+#include <stddef.h>
 #include <limits>
 #include "basic/value.h"
 
@@ -35,5 +36,7 @@ bool can_add_to_len_sorted_block(
 	uint64_t block_letter_limit,
 	uint64_t block_seq_limit = LEN_SORT_BLOCK_SEQ_LIMIT,
 	uint64_t block_raw_limit = LEN_SORT_BLOCK_RAW_LIMIT);
+
+double block_combo_chunk_size(size_t db_file_size, size_t query_file_size);
 
 } }

--- a/src/cluster/multinode/search.cpp
+++ b/src/cluster/multinode/search.cpp
@@ -18,11 +18,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <inttypes.h>
+#include <algorithm>
 #include "basic/statistics.h"
 #include "multinode.h"
+#include "len_sort.h"
 #include "../cluster.h"
 #include "run/workflow.h"
 #include "util/log_stream.h"
+#include "util/system/system.h"
 
 using std::vector;
 using std::string;
@@ -30,6 +33,19 @@ using std::unique_ptr;
 using std::tie;
 using std::runtime_error;
 using std::shared_ptr;
+
+double Cluster::Multinode::block_combo_chunk_size(size_t db_file_size, size_t query_file_size) {
+	const size_t max_file_size = std::max(db_file_size, query_file_size);
+	return (double)(max_file_size / 1000000000 + (max_file_size % 1000000000 != 0));
+}
+
+static double block_combo_chunk_size(const VolumedFile& volumes, int64_t r, int64_t i) {
+	const size_t db_size = file_size(volumes[r].path.c_str());
+	size_t query_size = db_size;
+	if (r != i)
+		query_size = file_size(volumes[i].path.c_str());
+	return Cluster::Multinode::block_combo_chunk_size(db_size, query_size);
+}
 
 static void run_all_vs_all(Job& job) {
 	job.log("Running all-vs-all search for round %d/%d", job.round() + 1, job.round_count());
@@ -66,7 +82,7 @@ static void run_block_combo(Job& job, const VolumedFile& volumes, int64_t r, int
 		config.query_file = { volumes[i].path };
 		config.self = false;
 	}
-	config.chunk_size = 1024;
+	config.chunk_size = block_combo_chunk_size(volumes, r, i);
 	config.database.clear();
 	config.fasta_index_file.clear();
 	if (config.db_size == 0)

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -43,8 +43,17 @@ static void len_sort_block_limits() {
 	require(!can_add_to_len_sorted_block(0, 0, 800, 1000, 10, 1000), "Expected an unrepresentable sequence to fail.");
 }
 
+static void block_combo_chunk_sizes() {
+	using Cluster::Multinode::block_combo_chunk_size;
+	require(block_combo_chunk_size(1, 1) == 1.0, "Expected tiny inputs to use a one GB chunk.");
+	require(block_combo_chunk_size(1000000000, 1) == 1.0, "Expected exact GB input to fit in one chunk.");
+	require(block_combo_chunk_size(1000000001, 1) == 2.0, "Expected chunk size to round up.");
+	require(block_combo_chunk_size(1024000000000, 1109673588218) == 1110.0, "Expected generated PSC block to fit without re-chunking.");
+}
+
 int run() {
 	len_sort_block_limits();
+	block_combo_chunk_sizes();
 	std::cerr << "Unit tests passed." << std::endl;
 	return 0;
 	//filestack();	


### PR DESCRIPTION
After the fixes in #968 #965 we restarted a 48B sequence clustering run. Even though the blocks are now correctly capped at 2^32-1 sequences, we encountered another problem downstream: For the linear block-combo search, the algorithm assumes a maximum chunk size of 1024GB, which causes problems downstream.

Run logfile:
[20260626_153616.log](https://github.com/user-attachments/files/29504663/20260626_153616.log)

## Summary

Fixes a crash in the multinode linear search path by preventing `Search::run` from re-splitting length-sorted input blocks.
 
## Problem

The multinode workflow first creates length-sorted block files in `len_sort()` and then runs linear block-combo searches over those exact `VolumedFile` entries.

However, `run_block_combo()` previously forced:

```cpp
config.chunk_size = 1024;
```

This means that a length-sorted block larger than 1024GB on disk could be split again inside the generic `Search::run` path:

- query blocks are loaded via `load_seqs(config.block_size(), ...)`
- reference blocks are loaded via `load_seqs(config.block_size(), ...)`
- `config.block_size()` is `config.chunk_size * 1e9`

For our dataset, one generated `input0.faa` block was ~1.11 TB on disk. Although length sorting had already produced a representation-safe block, the fixed 1024GB search chunk size caused `Search::run` to create additional internal query/reference blocks. That broke the multinode block-combo assumption that each `(r, i)` search operates on the already generated length-sort blocks.

## Fix

Instead of hardcoding 1024, `run_block_combo()` now derives `config.chunk_size` from the actual block files being compared:

```cpp
config.chunk_size = block_combo_chunk_size(volumes, r, i);
```

The helper takes the larger of the database/query block file sizes and rounds it up to whole decimal GB. This keeps the search chunk size large enough that `Search::run` does not split the length-sorted block again. This change makes the later generic search stage respect those precomputed block boundaries.

## Validation

We will rerun the 48B clustering and report back if this fixes it. However, we suspect more possible problems arising downstream, e.g. `greedy_vertex_cover()` uses an `unordered_map<string, OId>` without respecting memory limits. This, as well as other iterations/maps/buffers that go over the whole input db, can cause OOM crashes on very-large dbs where whole-db sample mappings are non-trivial.