### PR TITLE
Add missing #include <unistd.h>

### DIFF
--- a/src/util/io/file.cpp
+++ b/src/util/io/file.cpp
@@ -21,6 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
+#else
+#include <unistd.h> // unlink
 #endif
 #include <string.h> // strerror
 #include "file.h"


### PR DESCRIPTION
After the call to unlink() was added to util/io/file.cpp starting with v2.2.3, the build fails on toolchains that do not transitively include unistd.h, such as FreeBSD 15.1.  POSIX specifies that this function is declared in unistd.h, so add the missing #include.