### PR TITLE
Hsp(ApproxHsp) constructor: Initialize seed_only

### DIFF
--- a/src/basic/hssp.cpp
+++ b/src/basic/hssp.cpp
@@ -356,6 +356,7 @@ Hsp::Hsp(const IntermediateRecord& r, unsigned query_source_len, Loc qlen, Loc t
 
 Hsp::Hsp(const ApproxHsp& h, Loc qlen, Loc tlen) :
 	backtraced(true),
+	seed_only(false),
 	score(h.score),
 	frame(0),
 	length(h.query_range.length()),


### PR DESCRIPTION
Hsp::Hsp(const ApproxHsp&, Loc, Loc) did not initialize the seed_only member.  deepclust builds Hsps through this constructor for its approximate alignments.  When it evaluated to true, the SEED_ONLY flag was set on an otherwise full-length intermediate output record.  The multiblock join later parsed that record as seed-only, stopped four bytes short, and aborted with "Unexpected end of file", failing the deepclust-multiblock test.

This is undefined behavior.  The member happened to read as false on Linux and true on FreeBSD, so the crash surfaced only on FreeBSD.